### PR TITLE
Adding min and max collateral to snx.holderes, adding max output logs

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -257,8 +257,8 @@ program
 				max,
 				address,
 				addressesOnly,
-				minCollateral: minCollateral ? minCollateral * 1e18 : undefined,
-				maxCollateral: maxCollateral ? maxCollateral * 1e18 : undefined,
+				minCollateral,
+				maxCollateral,
 			})
 			.then(results => (addressesOnly ? results.map(({ address }) => address) : results))
 			.then(logResults({ json }))

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ module.exports = {
 						date: new Date(timestamp * 1000),
 					})),
 				)
-				.catch(err => console.error(err));
+				.catch(err => console.log(err));
 		},
 		clearedDeposits({ network = 'mainnet', fromAddress = undefined, toAddress = undefined, max = 100 }) {
 			return pageResults({
@@ -663,7 +663,7 @@ module.exports = {
 				.catch(err => console.error(err));
 		},
 
-		holders({ max = 100, address = undefined } = {}) {
+		holders({ max = 100, maxCollateral = undefined, minCollateral = undefined, address = undefined } = {}) {
 			return pageResults({
 				api: graphAPIEndpoints.snx,
 				max,
@@ -674,6 +674,8 @@ module.exports = {
 						orderDirection: 'desc',
 						where: {
 							id: address ? `\\"${address}\\"` : undefined,
+							collateral_lte: maxCollateral ? `\\"${maxCollateral}\\"` : undefined,
+							collateral_gte: minCollateral ? `\\"${minCollateral}\\"` : undefined,
 						},
 					},
 					properties: [

--- a/index.js
+++ b/index.js
@@ -674,8 +674,8 @@ module.exports = {
 						orderDirection: 'desc',
 						where: {
 							id: address ? `\\"${address}\\"` : undefined,
-							collateral_lte: maxCollateral ? `\\"${maxCollateral}\\"` : undefined,
-							collateral_gte: minCollateral ? `\\"${minCollateral}\\"` : undefined,
+							collateral_lte: maxCollateral ? `\\"${maxCollateral + '0'.repeat(18)}\\"` : undefined,
+							collateral_gte: minCollateral ? `\\"${minCollateral + '0'.repeat(18)}\\"` : undefined,
 						},
 					},
 					properties: [


### PR DESCRIPTION
- adds `minCollateral` and `maxCollateral` options to `snx.holders`
- adds logging output when `DEBUG=true` to show number of results in the CLI