### PR TITLE
split util functions into `utils.js` and fix hashes for snx.issued/burned

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,24 @@
+const ZERO_ADDRESS = '0x' + '0'.repeat(40);
+
+const hexToAscii = str => {
+	const hex = str.toString();
+	let out = '';
+	for (let n = 2; n < hex.length; n += 2) {
+		const nextPair = hex.substr(n, 2);
+		if (nextPair !== '00') {
+			out += String.fromCharCode(parseInt(nextPair, 16));
+		}
+	}
+	return out;
+};
+
+const roundTimestampTenSeconds = timestamp => Math.round(timestamp / 10) * 10;
+
+const getHashFromId = id => id.split('-')[0];
+
+module.exports = {
+	ZERO_ADDRESS,
+	hexToAscii,
+	roundTimestampTenSeconds,
+	getHashFromId,
+};


### PR DESCRIPTION
This PR fixes the hashes for "burn" and "issue" (currently, the hashes come with the "id", so they are invalid on mintr etherscan link).

I split it out to a reusable function (into "utils.js") and grabbed the other common functions.